### PR TITLE
set focus to first suggestion by down arrow key

### DIFF
--- a/autocomplete.js
+++ b/autocomplete.js
@@ -41,6 +41,10 @@ class Autocomplete {
         this.dropdown.hide();
         return;
       }
+      if (e.keyCode === 40) {
+        this.dropdown._menu.children[0]?.focus();
+        return;
+      }
     });
   }
 


### PR DESCRIPTION
Hi

I think it would be nice to use the arrow keys to select a suggestion.
This patch will set the focus to the first item in the dropdown when pressing the down arrow.

Let me know what you think of such behavior

Greetings
CBke