### PR TITLE
Fix bug: Navigation with cursor keys does not work

### DIFF
--- a/autocomplete.js
+++ b/autocomplete.js
@@ -12,7 +12,7 @@ class Autocomplete {
     this.dropdown = null;
 
     field.parentNode.classList.add('dropdown');
-    field.setAttribute('data-toggle', 'dropdown');
+    field.setAttribute('data-bs-toggle', 'dropdown');
     field.classList.add('dropdown-toggle');
 
     const dropdown = ce(`<div class="dropdown-menu" ></div>`);


### PR DESCRIPTION
The navigation keys did not work in the dropdown with the following exception:

```
bootstrap.esm.js?7b17:2393 Uncaught TypeError: Cannot read property '_selectMenuItem' of null
    at HTMLDivElement.dataApiKeydownHandler (bootstrap.esm.js?7b17:2393)
    at HTMLDocument.handler (bootstrap.esm.js?7b17:460)
```

The reason is that the data-toggle-field changed from `data-toggle` to `data-bs-toggle` in bootstrap 5.