### PR TITLE
filter by starting letters

### DIFF
--- a/autocomplete.js
+++ b/autocomplete.js
@@ -113,7 +113,7 @@ class Autocomplete {
           value: this.options.value ? entry[this.options.value] : entry
       };
 
-      if (removeDiacritics(item.label).toLowerCase().indexOf(removeDiacritics(lookup).toLowerCase()) >= 0) {
+      if (removeDiacritics(item.label).toLowerCase().startsWith(removeDiacritics(lookup).toLowerCase())) {
         items.appendChild(this.createItem(lookup, item));
         if (this.options.maximumItems > 0 && ++count >= this.options.maximumItems)
           break;


### PR DESCRIPTION
This autocomplete wasn't working as I expected.

For example, if I type "c" it brings up suggestions for the first entries that have "c" anywhere in their text.
![image](https://user-images.githubusercontent.com/36931193/226151166-5e53d681-e076-4072-a3ff-e9990461f43d.png)

This modification looks for entries that start with the given string, which is what I would typically expect from an autocomplete input.
![image](https://user-images.githubusercontent.com/36931193/226151136-5e57729b-2281-4572-9d6f-93489aeb523a.png)

Maybe there could be an option to pick between the two filter methods?